### PR TITLE
Fix "Race condition" (Mutex deadlock)

### DIFF
--- a/src/Server/Services/EntityService.lua
+++ b/src/Server/Services/EntityService.lua
@@ -180,6 +180,16 @@ function EntityService:EngineInit()
     self.EntityCreated = self.Classes.Signal.new()
     self.EntityDestroyed = self.Classes.Signal.new()
 
+    Network:HandleRequestType(NetRequestType.EntityRequest, function(client, _dt, base)
+        local entity = self:GetEntity(base)
+        
+        if (entity ~= nil) then
+            return self:PackEntityInfo({base})[1]
+        else
+            return nil
+        end
+    end)
+
     -- Gather map entity placements and log them
     for _, model in ipairs(CollectionService:GetTagged("EntityInit")) do
         if (not model:IsDescendantOf(workspace)) then continue end

--- a/src/Shared/Classes/Mutex.lua
+++ b/src/Shared/Classes/Mutex.lua
@@ -26,6 +26,7 @@ function Mutex.new()
 	local self = DeepObject.new({
         _Locked = false;
         _Lock = bindable;
+        Blocked = 0;
     })
 
 	return setmetatable(self, Mutex)
@@ -34,6 +35,7 @@ end
 
 -- Attempts to acquire the lock, yields the thread if already locked
 function Mutex:Lock()
+    self.Blocked += 1
     -- All threads that got in must check if this is still locked,
     --  just in case the owner thread is sleeping
     while (self._Locked) do
@@ -41,6 +43,7 @@ function Mutex:Lock()
     end
 
     self._Locked = true
+    self.Blocked -= 1
 end
 
 


### PR DESCRIPTION
Actually a mutex that was never released from the client-sided equipment change replicator. Upon receiving an update, but not having yet downloaded the entity data to apply the update on, we were exiting out of the function before releasing the lock. After inspection, a lock isn't necessary in the first place; however, the update-before-download issue was also resolved in this branch. The resolution was to actually finish implementing the EntityRequest endpoint that was only half-done up until now.